### PR TITLE
(maint) update for Elixir 1.2 compiler warnings

### DIFF
--- a/lib/exmoji/emoji_char.ex
+++ b/lib/exmoji/emoji_char.ex
@@ -89,7 +89,7 @@ defmodule Exmoji.EmojiChar do
   Is the `EmojiChar` represented by a doublebyte codepoint in Unicode?
   """
   def doublebyte?(%EmojiChar{unified: id}) do
-    id |> String.contains? "-"
+    id |> String.contains?("-")
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Exmoji.Mixfile do
     [
       app:           :exmoji,
       version:       "0.2.1",
-      elixir:        "~> 1.0.0-rc1",
+      elixir:        "~> 1.0",
       deps:          deps,
       test_coverage: [tool: ExCoveralls],
       name:          "Exmoji",


### PR DESCRIPTION
Prior to Elixir 1.2, the compiler did not warn about potentially
ambiguous usage of `|>`. This commit adds the parens to be explicit
about the parameters, mostly to mollify the compiler.