### PR TITLE
(maint) change json dep from jazz to poison

### DIFF
--- a/lib/exmoji.ex
+++ b/lib/exmoji.ex
@@ -20,7 +20,7 @@ defmodule Exmoji do
   @external_resource vendor_data_file
 
   rawfile = File.read! vendor_data_file
-  rawdata = Jazz.Decode.it! rawfile, keys: :atoms
+  rawdata = Poison.decode! rawfile, keys: :atoms
   emoji_chars = for char <- rawdata do
     %EmojiChar{
       name:         char.name,

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Exmoji.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:jazz,         "~> 0.2.1"},
+      {:poison,       "~> 1.5"},
       {:excoveralls,  "~> 0.3",                   only: :dev},
       {:benchfella,   github: "alco/benchfella",  only: :dev},
       {:earmark,      "~> 0.1",                   only: :dev},


### PR DESCRIPTION
Prior to this commit, we were using Jazz as the JSON parser for the
emoji data; however, Jazz appears to abandoned and Poison has been under
active development and is the de facto JSON parsing library for many of
the high profile Elixir frameworks, like Phoenix.

Although the runtime performance should be the same since the JSON parsing happens only at compile time, I've included the results of `mix bench` anyway.

`mix bench` with Jazz:
```
## EmojiCharBench
variant                     100000000   0.05 µs/op
variant?                    100000000   0.06 µs/op
doublebyte?                  10000000   0.39 µs/op
render - single               1000000   1.07 µs/op
render - double               1000000   1.27 µs/op
render - variant              1000000   1.31 µs/op
chars                         1000000   2.27 µs/op
## ExmojiBench
all_with_variants           100000000   0.02 µs/op
all_doublebyte              100000000   0.02 µs/op
all                         100000000   0.02 µs/op
from_unified                 10000000   0.71 µs/op
unified_to_char - single     10000000   0.93 µs/op
unified_to_char - double      1000000   1.17 µs/op
unified_to_char - triple      1000000   1.33 µs/op
char_to_unified - single      1000000   2.35 µs/op
char_to_unified - double       500000   3.86 µs/op
codepoints                      50000   34.14 µs/op
find_by_name - none              5000   385.54 µs/op
find_by_name - many              5000   389.00 µs/op
find_by_short_name - many        5000   449.47 µs/op
find_by_short_name - none        5000   462.60 µs/op
chars                            2000   980.36 µs/op
## ScannerBench
bscan(s1)                    10000000   0.13 µs/op
bscan(s3)                    10000000   0.58 µs/op
bscan(s2)                     1000000   1.10 µs/op
bscan(s0)                     1000000   1.72 µs/op
scan(s0)                      1000000   1.88 µs/op
scan(s1)                       500000   3.64 µs/op
scan(s2)                       200000   8.09 µs/op
scan(s3)                       100000   12.19 µs/op
rscan(s1)                       50000   38.64 µs/op
rscan(s3)                       10000   289.74 µs/op
rscan(s2)                        5000   556.49 µs/op
rscan(s0)                        2000   998.57 µs/op
```
`mix bench` with Poison:
```
## EmojiCharBench
variant                     100000000   0.04 µs/op
variant?                    100000000   0.05 µs/op
doublebyte?                  10000000   0.37 µs/op
render - single               1000000   1.05 µs/op
render - double               1000000   1.24 µs/op
render - variant              1000000   1.28 µs/op
chars                         1000000   2.23 µs/op
## ExmojiBench
all_doublebyte              100000000   0.02 µs/op
all                         100000000   0.02 µs/op
all_with_variants           100000000   0.02 µs/op
from_unified                 10000000   0.67 µs/op
unified_to_char - single     10000000   0.93 µs/op
unified_to_char - double      1000000   1.13 µs/op
unified_to_char - triple      1000000   1.38 µs/op
char_to_unified - single      1000000   2.33 µs/op
char_to_unified - double       500000   3.80 µs/op
codepoints                      50000   33.50 µs/op
find_by_name - none              5000   382.49 µs/op
find_by_name - many              5000   395.18 µs/op
find_by_short_name - none        5000   459.22 µs/op
find_by_short_name - many        5000   493.44 µs/op
chars                            1000   1014.78 µs/op
## ScannerBench
bscan(s1)                    10000000   0.13 µs/op
bscan(s3)                    10000000   0.56 µs/op
bscan(s2)                     1000000   1.06 µs/op
bscan(s0)                     1000000   1.66 µs/op
scan(s0)                      1000000   1.82 µs/op
scan(s1)                       500000   3.56 µs/op
scan(s2)                       500000   7.75 µs/op
scan(s3)                       100000   11.57 µs/op
rscan(s1)                       50000   38.66 µs/op
rscan(s3)                       10000   303.78 µs/op
rscan(s2)                        5000   580.72 µs/op
rscan(s0)                        2000   972.93 µs/op
```