### PR TITLE
Update Poison dependency.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Exmoji.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:poison,       "~> 1.5"},
+      {:poison,       "~> 2.2.0"},
       {:excoveralls,  "~> 0.4.5",                 only: :dev},
       {:benchfella,   "~> 0.3.1",                 only: :dev},
       {:earmark,      "~> 0.2.0",                 only: :dev},


### PR DESCRIPTION
Updating this dependency because it conflicts with the latest versions of Phoenix and Ecto. Ran tests and everything appears to pass on Elixir 1.3 (just a lot of warnings).