### PR TITLE
Replace Mix dependency :poison by :jason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,20 @@
 sudo: false
 language: elixir
 
-otp_release:
-  - 18.2
-  - 17.5
-
-elixir:
-  - 1.4.0
-  - 1.3.0
-  - 1.2.0
-  - 1.1.1
-
 matrix:
-  exclude:
-    - elixir: 1.2.0
-      otp_release: 17.5
-    - elixir: 1.3.0
-      otp_release: 17.5
-    - elixir: 1.4.0
-      otp_release: 17.5
+  include:
+    - otp_release: 22.3
+      elixir: 1.10
+    - otp_release: 21.3
+      elixir: 1.8
+    - otp_release: 21.3
+      elixir: 1.7
+    - otp_release: 20.3
+      elixir: 1.6
+    - otp_release: 19.3
+      elixir: 1.5
+    - otp_release: 19.0
+      elixir: 1.4
 
 env:
   - MIX_ENV=test

--- a/lib/exmoji.ex
+++ b/lib/exmoji.ex
@@ -20,7 +20,7 @@ defmodule Exmoji do
   @external_resource vendor_data_file
 
   rawfile = File.read! vendor_data_file
-  rawdata = Poison.decode! rawfile, keys: :atoms
+  rawdata = Jason.decode! rawfile, keys: :atoms
   emoji_chars = for char <- rawdata do
     %EmojiChar{
       name:         char.name,
@@ -197,7 +197,7 @@ defmodule Exmoji do
   # produce a string representation of the integer value of a codepoint, in hex
   # this should be zero-padded to a minimum of 4 digits
   defp padded_hex_string(<< cp_int_value :: utf8 >>) do
-    cp_int_value |> Integer.to_string(16) |> String.rjust(4,?0)
+    cp_int_value |> Integer.to_string(16) |> String.pad_leading(4, "0")
   end
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Exmoji.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:poison,       "~> 3.0"},
+      {:jason,        "~> 1.2"},
       {:excoveralls,  "~> 0.6",                 only: :dev},
       {:benchfella,   "~> 0.3",                 only: :dev},
       {:earmark,      "~> 1.1",                 only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Exmoji.Mixfile do
     [
       app:           :exmoji,
       version:       "0.2.2",
-      elixir:        "~> 1.1",
+      elixir:        "~> 1.4",
       deps:          deps(),
       test_coverage: [tool: ExCoveralls],
       name:          "Exmoji",


### PR DESCRIPTION
A lot of Hex packages (Phoenix and Ecto to name the bigger ones) requiring JSON encoding/decoding have moved to [`:jason`](https://hex.pm/packages/jason) lately.

This PR is a pure replacement, an other possibility would be make the JSON decoder configurable.